### PR TITLE
Make `RegistrateDataProvider.DataInfo` public to allow custom `ProviderType`s

### DIFF
--- a/src/main/java/com/tterrag/registrate/providers/RegistrateDataProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateDataProvider.java
@@ -37,7 +37,7 @@ public class RegistrateDataProvider implements DataProvider {
     private final String mod;
     private final Map<ProviderType<?>, RegistrateProvider> subProviders = new LinkedHashMap<>();
 
-    record DataInfo(FabricDataGenerator generator, ExistingFileHelper helper) {}
+    public record DataInfo(FabricDataGenerator generator, ExistingFileHelper helper) {}
 
     public RegistrateDataProvider(AbstractRegistrate<?> parent, String modid, FabricDataGenerator generator, ExistingFileHelper helper) {
         this.mod = modid;


### PR DESCRIPTION
https://github.com/Fabricators-of-Create/Registrate-Refabricated/blob/e719b07f72b45e0a1abd42486fb9a817a589121d/src/main/java/com/tterrag/registrate/providers/ProviderType.java#L19-L33

As mentioned in documentation, third-party types are supported by `ProviderType`, but `RegistrateDataProvider.DataInfo` is package-private, making it impossible to create third-party types since `DataInfo` is essential.

This PR is an extremely simple fix for that.