### PR TITLE
Build: Update MixinExtras.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,6 @@ repositories {
     maven { url = "https://maven.quiltmc.org/repository/release" }
     maven { url = "https://repo.maven.apache.org/maven2" }
     maven { url = "https://mvn.devos.one/snapshots" }
-    maven {
-        url = "https://jitpack.io"
-        content {
-            includeGroup("com.github.llamalad7.mixinextras")
-        }
-    }
 }
 
 dependencies {
@@ -46,8 +40,8 @@ dependencies {
     modApi(include("io.github.fabricators_of_create.Porting-Lib:tags:${project.porting_lib_version}")) { exclude(group: "io.vram") }
     modApi(include("io.github.fabricators_of_create.Porting-Lib:model_generators:${project.porting_lib_version}")) { exclude(group: "io.vram") }
     modApi(include("io.github.fabricators_of_create.Porting-Lib:data:${project.porting_lib_version}")) { exclude(group: "io.vram") }
-    implementation(include("com.github.llamalad7.mixinextras:mixinextras-fabric:${project.mixin_extras_version}"))
-    annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:${project.mixin_extras_version}")
+    implementation(include("io.github.llamalad7:mixinextras-fabric:${project.mixin_extras_version}"))
+    annotationProcessor("io.github.llamalad7:mixinextras-fabric:${project.mixin_extras_version}")
 
     compileOnly("org.projectlombok:lombok:1.18.22")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs = -Xmx1G
 # filled in at build
 mod_version = 1.3.<patch>
 minecraft_version = 1.20.1
-loader_version = 0.14.21
+loader_version = 0.14.25
 fabric_version = 0.86.0+1.20.1
 porting_lib_version = 2.1.1090+1.20
-mixin_extras_version = 0.2.0-beta.6
+mixin_extras_version = 0.3.6
 
 # Mappings
 # https://lambdaurora.dev/tools/import_quilt.html

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -33,7 +33,7 @@
   "accessWidener": "registrate-fabric.accesswidener",
 
   "depends": {
-    "fabricloader": ">=0.12.10",
+    "fabricloader": ">=0.14.25",
     "fabric": "*"
   },
 


### PR DESCRIPTION
`0.2.0-beta.6` has been unsupported for a very long time, and you are using the old maven group which causes issues for other mods in dev.