### PR TITLE
Possible fix registrate loot providers

### DIFF
--- a/src/main/java/com/tterrag/registrate/mixin/accessor/LootTableProviderAccessor.java
+++ b/src/main/java/com/tterrag/registrate/mixin/accessor/LootTableProviderAccessor.java
@@ -11,6 +11,7 @@ import net.minecraft.data.loot.LootTableProvider.SubProviderEntry;
 
 @Mixin(LootTableProvider.class)
 public interface LootTableProviderAccessor {
+    @Mutable
     @Accessor
-    List<SubProviderEntry> getSubProviders();
+    void setSubProviders(List<SubProviderEntry> entries);
 }

--- a/src/main/java/com/tterrag/registrate/providers/loot/RegistrateBlockLootTables.java
+++ b/src/main/java/com/tterrag/registrate/providers/loot/RegistrateBlockLootTables.java
@@ -8,6 +8,7 @@ import javax.annotation.processing.Generated;
 import com.tterrag.registrate.AbstractRegistrate;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.loot.BlockLootSubProvider;
@@ -25,12 +26,12 @@ import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class RegistrateBlockLootTables extends VanillaBlockLoot implements RegistrateLootTables {
+public class RegistrateBlockLootTables extends FabricBlockLootTableProvider implements RegistrateLootTables {
     private final AbstractRegistrate<?> parent;
     private final Consumer<RegistrateBlockLootTables> callback;
 
     public RegistrateBlockLootTables(HolderLookup.Provider provider, AbstractRegistrate<?> parent, Consumer<RegistrateBlockLootTables> callback, FabricDataOutput output) {
-        super(provider);
+        super(output, CompletableFuture.completedFuture(provider));
         this.parent = parent;
         this.callback = callback;
     }

--- a/src/main/java/com/tterrag/registrate/providers/loot/RegistrateLootTableProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/loot/RegistrateLootTableProvider.java
@@ -67,10 +67,11 @@ public class RegistrateLootTableProvider extends LootTableProvider implements Re
 
     private CompletableFuture<HolderLookup.Provider> provider;
 
-    public RegistrateLootTableProvider(AbstractRegistrate<?> parent, PackOutput packOutput, CompletableFuture<HolderLookup.Provider> provider) {
-        super(packOutput, Set.of(), ((LootTableProviderAccessor) VanillaLootTableProvider.create(packOutput, provider)).getSubProviders(), provider);
+    public RegistrateLootTableProvider(AbstractRegistrate<?> parent, FabricDataOutput packOutput, CompletableFuture<HolderLookup.Provider> provider) {
+        super(packOutput, Set.of(), List.of(), provider);
         this.parent = parent;
         this.provider = provider;
+        ((LootTableProviderAccessor) this).setSubProviders(getTables(packOutput));
     }
 
     public HolderLookup.Provider getProvider(){


### PR DESCRIPTION
You likely had your reasons to move away from how it was on 1.20, but I was looking at porting something to 1.21 and noticed loot generation was not working anymore due to some changes.
I guess the 1.21 branch is still not ready, so feel free to just decline this if it does not fit your plans, just thought I might as well open a PR since I fixed it for me locally by reverting most of the logic back to how it was on 1.20.