### PR TITLE
Datagen related fixes for recipes & loot tables

### DIFF
--- a/src/main/java/com/tterrag/registrate/mixin/accessor/LootTableProviderAccessor.java
+++ b/src/main/java/com/tterrag/registrate/mixin/accessor/LootTableProviderAccessor.java
@@ -11,6 +11,7 @@ import net.minecraft.data.loot.LootTableProvider.SubProviderEntry;
 
 @Mixin(LootTableProvider.class)
 public interface LootTableProviderAccessor {
+    @Mutable
     @Accessor
-    List<SubProviderEntry> getSubProviders();
+    void setSubProviders(List<SubProviderEntry> entries);
 }

--- a/src/main/java/com/tterrag/registrate/providers/RegistrateRecipeProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/RegistrateRecipeProvider.java
@@ -322,6 +322,11 @@ public class RegistrateRecipeProvider extends FabricRecipeProvider implements Re
             .save(this, safeId(result.get()));
     }
 
+    @Override
+    public ResourceLocation getRecipeIdentifier(ResourceLocation identifier) {
+        return super.getRecipeIdentifier(identifier);
+    }
+
     // @formatter:off
     // GENERATED START - DO NOT EDIT BELOW THIS LINE
 

--- a/src/main/java/com/tterrag/registrate/providers/loot/RegistrateBlockLootTables.java
+++ b/src/main/java/com/tterrag/registrate/providers/loot/RegistrateBlockLootTables.java
@@ -8,6 +8,7 @@ import javax.annotation.processing.Generated;
 import com.tterrag.registrate.AbstractRegistrate;
 
 import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.loot.BlockLootSubProvider;
@@ -25,12 +26,12 @@ import net.minecraft.world.level.storage.loot.providers.number.NumberProvider;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class RegistrateBlockLootTables extends VanillaBlockLoot implements RegistrateLootTables {
+public class RegistrateBlockLootTables extends FabricBlockLootTableProvider implements RegistrateLootTables {
     private final AbstractRegistrate<?> parent;
     private final Consumer<RegistrateBlockLootTables> callback;
 
     public RegistrateBlockLootTables(HolderLookup.Provider provider, AbstractRegistrate<?> parent, Consumer<RegistrateBlockLootTables> callback, FabricDataOutput output) {
-        super(provider);
+        super(output, CompletableFuture.completedFuture(provider));
         this.parent = parent;
         this.callback = callback;
     }

--- a/src/main/java/com/tterrag/registrate/providers/loot/RegistrateLootTableProvider.java
+++ b/src/main/java/com/tterrag/registrate/providers/loot/RegistrateLootTableProvider.java
@@ -67,10 +67,11 @@ public class RegistrateLootTableProvider extends LootTableProvider implements Re
 
     private CompletableFuture<HolderLookup.Provider> provider;
 
-    public RegistrateLootTableProvider(AbstractRegistrate<?> parent, PackOutput packOutput, CompletableFuture<HolderLookup.Provider> provider) {
-        super(packOutput, Set.of(), ((LootTableProviderAccessor) VanillaLootTableProvider.create(packOutput, provider)).getSubProviders(), provider);
+    public RegistrateLootTableProvider(AbstractRegistrate<?> parent, FabricDataOutput packOutput, CompletableFuture<HolderLookup.Provider> provider) {
+        super(packOutput, Set.of(), List.of(), provider);
         this.parent = parent;
         this.provider = provider;
+        ((LootTableProviderAccessor) this).setSubProviders(getTables(packOutput));
     }
 
     public HolderLookup.Provider getProvider(){


### PR DESCRIPTION
## `public getRecipeIdentifier`
 `RegistrateRecipeProvider` extends both `FabricRecipeProvider` and `RecipeOutput`. 
`FabricRecipeProvider` protected method called `getRecipeIdentifier`, fabrics `FabricRecipeExporter` adds a method with the same name, but public,  to `RecipeOutput`.
Fabric also calls this method on `RecipeOutput` [here](https://github.com/FabricMC/fabric/blob/1.21.1/fabric-data-generation-api-v1/src/main/java/net/fabricmc/fabric/mixin/datagen/recipe/AllCraftingRecipeJsonBuildersMixin.java), which fails with registrate because it's being shadowed by the protected method. 
Overwriting it and making it public again solves this problem.

## LootTable stuff
Previously registrate did not replace the sub providers anymore, meaning the registrate loot datagen did never get executed.
There might be other solutions, but this felt clean enough and works